### PR TITLE
Fix `l.rb` working in sub-directories of the git repo

### DIFF
--- a/libexec/l.rb
+++ b/libexec/l.rb
@@ -363,8 +363,8 @@ module LdotRB
   module GitChangedFiles
     def self.cmd(config, file_paths)
       [
-        "git diff --no-ext-diff --name-only #{config.changed_ref}", # changed files
-        "git ls-files --others --exclude-standard"                  # added files
+        "git diff --no-ext-diff --relative --name-only #{config.changed_ref}", # changed files
+        "git ls-files --others --exclude-standard"                             # added files
       ]
         .map{ |c| "#{c} -- #{file_paths.join(" ")}" }
         .join(" && ")


### PR DESCRIPTION
This fixes `l.rb` working in sub-directories of the git repo by
adding the `--relative` flag to the `git diff` command. For
example, if you have the following folder structure:

    gitrepo
     - .git
     - subdirectory
        - .l.yml
        - files

and you are in the `subdirectory` folder, if you ran `l -c` to
detect changes in your `files` folder, it previously wouldn't see
any. This is because the `git diff` command returned results like
`gitrepo/subdirectory/files/something` and then the linter running
logic wouldn't think it's a valid file for it to run. The
`--relative` option makes it return `subdirectory/files/something`
which works as expected with the rest of the linter running logic.
