### PR TITLE
add -a CLI options to run in autocorrect mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 A lint runner. Run locally configured lint commands via a generic CLI with standard options/features.
 
-
 ## Install
 
 Open a terminal and run this command ([view source](https://git.io/l.rb--install)):
@@ -30,6 +29,7 @@ ignored_file_paths:
 linters:
   - name: "Rubocop"
     cmd: "rubocop"
+    autocorrect_cmd: "rubocop -a"
     extensions:
       - ".rb"
     cli_abbrev: "u"
@@ -69,7 +69,7 @@ $ l
 #### Debug Mode
 
 ```
-$ runlints -d
+$ l -d
 [DEBUG] CLI init and parse...          (6.686 ms)
 [DEBUG] 0 specified source files:
 Running Rubocop
@@ -89,7 +89,7 @@ This option, in addition to executing the linter command, outputs a bunch of det
 #### Changed Only
 
 ```
-$ runlints -d -c
+$ l -d -c
 [DEBUG] CLI init and parse...            (7.138 ms)
 [DEBUG] Lookup changed source files...   (24.889 ms)
 [DEBUG]   `git diff --no-ext-diff --name-only  -- . && git ls-files --others --exclude-standard -- .`
@@ -110,7 +110,7 @@ This runs a git command to determine which files have been updated (relative to 
 You can specify a custom git ref to use instead:
 
 ```
-$ runlints -d -c -r master
+$ l -d -c -r master
 [DEBUG] CLI init and parse...            (6.933 ms)
 [DEBUG] Lookup changed source files...   (162.297 ms)
 [DEBUG]   `git diff --no-ext-diff --name-only master -- . && git ls-files --others --exclude-standard -- .`
@@ -130,7 +130,7 @@ Running SCSS Lint
 #### Dry-Run
 
 ```
-$ runlints --dry-run
+$ l --dry-run
 Running Rubocop
 rubocop .
 
@@ -145,16 +145,26 @@ scss-lint .
 
 This option only outputs the linter command it would have run. It does not execute the linter command.
 
+#### Autocorrect
+
+```
+$ l --dry-run -a
+Running Rubocop
+rubocop -a .
+```
+
+This option runs the optional `autocorrect_cmd` configured on the linters. If linters do not define an autocorrect cmd, they will not be run.
+
 #### Specifically run or don't run individual linters
 
 ```
-$ runlints --rubocop
+$ l --rubocop
 Running Rubocop
 rubocop .
 ```
 
 ```
-$ runlints --no-es-lint
+$ l --no-es-lint
 Running Rubocop
 rubocop .
 
@@ -168,7 +178,7 @@ Each linter gets a CLI option that allows you to toggle it on/off. If no options
 #### List
 
 ```
-$ runlints -l
+$ l -l
 app/file1.rb
 app/file2.js
 app/file3.scss

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -25,7 +25,8 @@ class LdotRB::Config
 
     should have_readers :stdout, :version
     should have_readers :source_file_paths, :ignored_file_paths, :linter_hashes
-    should have_imeths  :changed_only, :changed_ref, :dry_run, :list, :debug
+    should have_imeths  :changed_only, :changed_ref
+    should have_imeths :dry_run, :list, :autocorrect, :debug
     should have_imeths  :apply
     should have_imeths :debug_msg, :debug_puts, :puts, :print
     should have_imeths :bench, :bench_start_msg, :bench_finish_msg
@@ -48,6 +49,7 @@ class LdotRB::Config
       assert_that(subject.changed_ref).is_empty
       assert_that(subject.dry_run).is_false
       assert_that(subject.list).is_false
+      assert_that(subject.autocorrect).is_false
       assert_that(subject.debug).is_false
     end
 
@@ -57,6 +59,7 @@ class LdotRB::Config
         :changed_ref  => Factory.string,
         :dry_run      => true,
         :list         => true,
+        :autocorrect  => true,
         :debug        => true
       }
       subject.apply(settings)
@@ -65,6 +68,7 @@ class LdotRB::Config
       assert_that(subject.changed_ref).equals(settings[:changed_ref])
       assert_that(subject.dry_run).equals(settings[:dry_run])
       assert_that(subject.list).equals(settings[:list])
+      assert_that(subject.autocorrect).equals(settings[:autocorrect])
       assert_that(subject.debug).equals(settings[:debug])
     end
 

--- a/test/unit/linter_tests.rb
+++ b/test/unit/linter_tests.rb
@@ -17,24 +17,29 @@ class LdotRB::Linter
       unit_class.new(
         name: name1,
         cmd: cmd1,
+        autocorrect_cmd: autocorrect_cmd1,
         extensions: [extension1]
       )
     }
 
     let(:name1) { Factory.string }
     let(:cmd1) { Factory.string }
+    let(:autocorrect_cmd1) { Factory.string }
     let(:extension1) { ".rb" }
     let(:applicable_source_files) { ["app/file1.rb", "app/file2.rb"] }
     let(:not_applicable_source_file) { "app/file2.js" }
     let(:cli_option_name1) { Factory.string }
     let(:cli_abbrev1) { Factory.string(1) }
 
-    should have_readers :name, :cmd, :extensions
+    should have_readers :name, :cmd, :autocorrect_cmd, :extensions
     should have_readers :cli_option_name, :cli_abbrev
+    should have_imeths :specifically_enabled=, :specifically_enabled?, :enabled?
+    should have_imeths :cmd_str, :autocorrect_cmd_str
 
     should "know its attributes" do
       assert_that(subject.name).equals(name1)
       assert_that(subject.cmd).equals(cmd1)
+      assert_that(subject.autocorrect_cmd).equals(autocorrect_cmd1)
       assert_that(subject.extensions).equals([extension1])
       assert_that(subject.cli_option_name).equals(name1)
       assert_that(subject.cli_abbrev).equals(name1[0])
@@ -43,6 +48,7 @@ class LdotRB::Linter
         unit_class.new(
           name: name1,
           cmd: cmd1,
+          autocorrect_cmd: autocorrect_cmd1,
           extensions: [extension1],
           cli_option_name: cli_option_name1,
           cli_abbrev: cli_abbrev1
@@ -68,14 +74,28 @@ class LdotRB::Linter
       assert_that(subject.enabled?).is_false
     end
 
-    should "know its cmd_str given applicable source files" do
+    should "know its cmd str" do
+      assert_that(subject.cmd_str(nil)).equals("#{cmd1} .")
       assert_that(subject.cmd_str(applicable_source_files)).equals(
         "#{cmd1} #{applicable_source_files.join(" ")}"
       )
+      assert_that(subject.cmd_str([not_applicable_source_file])).is_nil
     end
 
-    should "know its cmd_str given not applicable source files" do
-      assert_that(subject.cmd_str([not_applicable_source_file])).is_nil
+    should "know its autocorrect cmd str" do
+      assert_that(subject.autocorrect_cmd_str(nil))
+        .equals("#{autocorrect_cmd1} .")
+      assert_that(subject.autocorrect_cmd_str(applicable_source_files)).equals(
+        "#{autocorrect_cmd1} #{applicable_source_files.join(" ")}"
+      )
+      assert_that(subject.autocorrect_cmd_str([not_applicable_source_file]))
+        .is_nil
+
+      Assert.stub(subject, :autocorrect_cmd){ nil }
+      assert_that(subject.autocorrect_cmd_str(nil)).is_nil
+      assert_that(subject.autocorrect_cmd_str(applicable_source_files)).is_nil
+      assert_that(subject.autocorrect_cmd_str([not_applicable_source_file]))
+        .is_nil
     end
   end
 end


### PR DESCRIPTION
This allows you to configure and `autocorrect_cmd:` in your YML
config files. If you run with the `-a` flag and, in this mode,
any linters with autocorrect cmds will run using that command.

E.g. you could configure

```yml
linters:
  - name: "Rubocop"
    cmd: "rubocop"
    autocorrect_cmd: "rubocop -a"
    extensions:
      - ".rb"
    cli_abbrev: "u"
```

Then running `l -a` would run `rubocop -a` against your source.

# Demo

![imagezs1iz](https://user-images.githubusercontent.com/82110/117168806-1e491780-ad8e-11eb-940b-ab519c5032b4.jpg)
